### PR TITLE
Tool cache fixes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,6 +47,12 @@ jobs:
       with:
         default: 3.7.3
 
+    - name: pyenv + python 3.7.3 cached
+      id: pyenv2
+      uses: "gabrielfalcao/pyenv-action@master"
+      with:
+        default: 3.7.3
+
     - name: List python versions
       run: pyenv versions
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -9551,7 +9551,7 @@ class PyEnvInstaller {
                 const cache_key = `pyenv-archive.zip`;
                 const cache_version = this.pyenv_version;
                 const cached_archive = tc.find(cache_key, cache_version);
-                if (utils.file_exists(cached_archive)) {
+                if (cached_archive) {
                     return accept(path.join(cached_archive, cache_key));
                 }
                 console.log(`downloading ${this.archive_url}`);
@@ -9578,8 +9578,9 @@ class PyEnvInstaller {
     installFromArchive(archive_path) {
         return __awaiter(this, void 0, void 0, function* () {
             return new Promise((accept, reject) => {
-                if (utils.file_exists(this.archive_path)) {
-                    return accept(path.join(this.archive_path, `pyenv-${this.pyenv_version}`));
+                const cached_pyenv_root = tc.find('pyenv_root', this.pyenv_version);
+                if (cached_pyenv_root) {
+                    return accept(cached_pyenv_root);
                 }
                 tc.extractZip(archive_path, tc.find('pyenv_archive', this.pyenv_version))
                     .then(inflation_path => {
@@ -9706,7 +9707,7 @@ class EnvironmentManager {
                 const cache_key = `pyenv-${this.pyenv_version}-python`;
                 const cache_version = version;
                 const cached_python = tc.find(cache_key, cache_version);
-                if (utils.folder_exists(cached_python)) {
+                if (cached_python) {
                     console.log(`Using cached python installation ${version}`);
                     return accept(cached_python);
                 }
@@ -9756,7 +9757,7 @@ class EnvironmentManager {
             return new Promise((accept, reject) => {
                 const version = this.context.inputs.default_version;
                 const cached_python = tc.find(`pyenv-${this.pyenv_version}-python`, version);
-                if (!utils.folder_exists(cached_python)) {
+                if (!cached_python) {
                     return reject(new Error(`python ${version} was not installed via pyenv`));
                 }
                 exec

--- a/src/engine.ts
+++ b/src/engine.ts
@@ -94,7 +94,7 @@ export class PyEnvInstaller {
       const cache_version = this.pyenv_version;
       const cached_archive = tc.find(cache_key, cache_version);
 
-      if (utils.file_exists(cached_archive)) {
+      if (cached_archive) {
         return accept(path.join(cached_archive, cache_key));
       }
       console.log(`downloading ${this.archive_url}`);
@@ -126,10 +126,9 @@ export class PyEnvInstaller {
 
   async installFromArchive(archive_path: string): Promise<string> {
     return new Promise<string>((accept, reject) => {
-      if (utils.file_exists(this.archive_path)) {
-        return accept(
-          path.join(this.archive_path, `pyenv-${this.pyenv_version}`)
-        );
+      const cached_pyenv_root = tc.find('pyenv_root', this.pyenv_version);
+      if (cached_pyenv_root) {
+        return accept(cached_pyenv_root);
       }
       tc.extractZip(archive_path, tc.find('pyenv_archive', this.pyenv_version))
         .then(inflation_path => {
@@ -296,7 +295,7 @@ export class EnvironmentManager {
       const cache_version = version;
 
       const cached_python = tc.find(cache_key, cache_version);
-      if (utils.folder_exists(cached_python)) {
+      if (cached_python) {
         console.log(`Using cached python installation ${version}`);
         return accept(cached_python);
       }
@@ -353,7 +352,7 @@ export class EnvironmentManager {
         `pyenv-${this.pyenv_version}-python`,
         version
       );
-      if (!utils.folder_exists(cached_python)) {
+      if (!cached_python) {
         return reject(
           new Error(`python ${version} was not installed via pyenv`)
         );


### PR DESCRIPTION
This fixes a couple bugs in the tool cache:

- `pyenv-archive.zip` will not be redownloaded if it is already cached.
- `pyenv_root` will not be recreated (through reinstalling `pyenv`) if it is already cached. This avoids wiping out links to previously cached python installs, causing jobs to fail on persistent runners.

One of the integration tests is modified to use this action twice in the same job, which triggers the bug in the old code but is fixed by this PR. A persistent runner is not needed for this test.

The npm tests are left alone, as they do not currently install or test any python version after installing pyenv, and that's the only way to trigger a failure.

Resolves #320.