### PR TITLE
Upgrade node infra from node16 -> node20.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
-    - name: set node.js 16.x
-      uses: actions/setup-node@v3
+    - name: set node.js 20.x
+      uses: actions/setup-node@v4
       with:
-        node-version: 16.x
+        node-version: 20
 
     - name: install dependencies
       run: npm ci
@@ -31,7 +31,7 @@ jobs:
     name: "Integration Tests: Setup"
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: setup pyenv
       id: pyenv
@@ -54,7 +54,7 @@ jobs:
     name: "Integration Tests: Caches Default"
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: pyenv + python 3.7.16
       id: pyenv
@@ -82,7 +82,7 @@ jobs:
     name: "Integration Tests: Caches Multiple Versions"
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: pyenv + python 3.8.16 and 3.7.16
       id: pyenv
@@ -119,7 +119,7 @@ jobs:
     name: "Integration Tests: Run commands after each version installation"
     steps:
     - name: checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     - name: python 3.7.16 and 3.8.16 with latest pip
       id: pyenv

--- a/README.rst
+++ b/README.rst
@@ -52,7 +52,7 @@ each of them and run pytest.
              - 3.9
 
        steps:
-       - uses: actions/checkout@v3
+       - uses: actions/checkout@v4
        - name: Install python version
          uses: gabrielfalcao/pyenv-action@v18
          with:

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'Pyenv Build'
 author: 'Gabriel Falcão'
 description: 'Enables use of pyenv within build'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'dist/index.js'
 
 inputs:


### PR DESCRIPTION
The GitHub node16 CI infrastructure is going away this spring:
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/

This includes upgrading actions we use in our own CI that currently warn
due to this same issue of node16 going away in the spring.

Fixes #443