### PR TITLE
Update Version of pyenv in index.js

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -13481,7 +13481,7 @@ function wrappy (fn, cb) {
 
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.PYENV_VERSION = void 0;
-exports.PYENV_VERSION = '2.3.28';
+exports.PYENV_VERSION = '2.3.35';
 
 
 /***/ }),


### PR DESCRIPTION
Looks like this was missed during the last two pyenv version bumps, so v18 is still using pyenv v2.3.28